### PR TITLE
Fix module docstring extraction

### DIFF
--- a/redgettext.py
+++ b/redgettext.py
@@ -82,10 +82,11 @@ class TokenEater:
                     self.__add_entry(safe_eval(string), lineno, is_docstring=True)
                     self.__fresh_module = False
                     return
-                elif ttype not in (tokenize.COMMENT, tokenize.NL):
-                    self.__fresh_module = False
+                if ttype in (tokenize.COMMENT, tokenize.NL, tokenize.ENCODING):
+                    return
+                self.__fresh_module = False
             # class or method docstring?
-            elif ttype == tokenize.NAME and string in ("class", "def"):
+            if ttype == tokenize.NAME and string in ("class", "def"):
                 self.__state = self.__suite_seen
                 return
         # cog or command docstring?


### PR DESCRIPTION
Work mostly copied from https://github.com/python/cpython/pull/95732 (authored by me :))

It's unlikely that someone uses the docstring extraction in redgettext but there's no good reason not to keep up with upstream here.