### PR TITLE
Rewrite redgettext to use ast module

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 88
+max-line-length = 99
 select = C,E,F,W
 # E203 whitespace before ':'
 #   incompatible with Black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "libcst",
     "polib",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+
 [project.scripts]
 redgettext = "redgettext:main"
 
@@ -51,3 +56,6 @@ version = {attr = "redgettext.__version__"}
 [tool.black]
 line-length = 99
 target-version = ['py38']
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,5 @@ redgettext = "redgettext:main"
 version = {attr = "redgettext.__version__"}
 
 [tool.black]
+line-length = 99
 target-version = ['py38']
-include = '\.py$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,9 @@ keywords = [
     "redbot",
     "red-discordbot",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
+    "libcst",
     "polib",
 ]
 dynamic = ["version"]

--- a/tests/call_test.py
+++ b/tests/call_test.py
@@ -1,0 +1,61 @@
+from textwrap import dedent
+
+import polib
+import pytest
+
+from redgettext import Options
+from tests.utils import FILENAME, get_extractor, get_test_potfile
+
+
+class TestGettextCalls:
+    OPTIONS = Options()
+
+    @pytest.mark.parametrize(
+        "source",
+        (
+            '''_("""t""" r'ex' u't')''',
+            """obj._("text")""",
+            """\
+            _(
+                "t"
+                "e"
+                "xt"
+            )
+            """,
+            '''f"{_('text')}"''',
+            '''rf"{_('text')}"''',
+            '''f"""{f"{_('text')}"}"""''',
+            '''f"{obj._('text')}"''',
+        ),
+    )
+    def test_gettext(self, source: str) -> None:
+        extractor = get_extractor(dedent(source), self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile(
+            polib.POEntry(msgid="text", occurrences=[(FILENAME, 1)])
+        )
+
+    def test_gettext_call_on_call(self) -> None:
+        extractor = get_extractor("""type(str)('text')""", self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+    def test_gettext_fstrings_with_wrong_input(self) -> None:
+        extractor = get_extractor('''f"{_(f'text {repl}')}"''', self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+    def test_gettext_wrong_input_type(self) -> None:
+        extractor = get_extractor("""_(1)""", self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+    def test_gettext_multiple_args(self) -> None:
+        extractor = get_extractor("""_('foo', 'bar')""", self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+    def test_gettext_kwargs(self) -> None:
+        extractor = get_extractor("""_('foo', bar='baz')""", self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+    def test_gettext_with_partially_wrong_expression(self) -> None:
+        extractor = get_extractor("""_(f'foo') + _('bar')""", self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile(
+            polib.POEntry(msgid="bar", occurrences=[(FILENAME, 1)])
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from freezegun import freeze_time
+
+
+@pytest.fixture(autouse=True)
+def _setup_driver():
+    with freeze_time():
+        yield

--- a/tests/docstring_test.py
+++ b/tests/docstring_test.py
@@ -1,0 +1,302 @@
+import itertools
+from typing import Tuple
+
+import polib
+import pytest
+
+from redgettext import Options
+from tests.utils import FILENAME, get_extractor, get_test_potfile
+
+
+REAL_DOCSTRINGS = ('"""doc"""', "r'''doc'''", "R'doc'", 'u"doc"', "'d' 'o'\\\n'c'")
+FAKE_DOCSTRINGS = ('b"""doc"""', 'f"""doc"""')
+CLASS_DECORATORS = ("cog_i18n",)
+FUNCTION_DECORATORS = ("command", "group")
+INVALID_DECORATORS = ("commands", "staticmethod")
+
+MODULE_TMPL = "{docstring}\n"
+ASYNC_FUNCTION_TMPL = """\
+async def func(arg1, arg2):
+    {docstring}
+"""
+FUNCTION_TMPL = """\
+def func(arg1, arg2):
+    {docstring}
+"""
+CLASS_TMPL = """\
+class Example:
+    {docstring}
+"""
+ASYNC_METHOD_TMPL = """\
+class Example:
+    async def meth(self, arg1, arg2):
+        {docstring}
+"""
+METHOD_TMPL = """\
+class Example:
+    def meth(self, arg1, arg2):
+        {docstring}
+"""
+COMMAND_ASYNC_FUNCTION_TMPL = """\
+@commands.{deco_name}()
+async def func(arg1, arg2):
+    {docstring}
+"""
+COMMAND_FUNCTION_TMPL = """\
+@commands.{deco_name}()
+@asyncio.coroutine
+def func(arg1, arg2):
+    {docstring}
+"""
+COMMAND_CLASS_TMPL = """\
+@{deco_name}(_)
+class Example(commands.Cog):
+    {docstring}
+"""
+COMMAND_ASYNC_METHOD_TMPL = """\
+class Example(commands.Cog):
+    @commands.{deco_name}()
+    async def meth(self, ctx, arg1, arg2):
+        {docstring}
+"""
+COMMAND_METHOD_TMPL = """\
+class Example(commands.Cog):
+    @commands.{deco_name}()
+    @asyncio.coroutine
+    def meth(self, ctx, arg1, arg2):
+        {docstring}
+"""
+
+
+def generate_code(template: str, lineno: int = 0, **kwargs: Tuple[str]) -> Tuple[str]:
+    it = itertools.product(*kwargs.values())
+    if not lineno:
+        return tuple(template.format(**dict(zip(kwargs, product))) for product in it)
+    return tuple((template.format(**dict(zip(kwargs, product))), lineno) for product in it)
+
+
+class TestDocstrings:
+    OPTIONS = Options(docstrings=True)
+
+    @pytest.mark.parametrize(
+        "source,lineno",
+        (
+            *generate_code(MODULE_TMPL, 1, docstring=REAL_DOCSTRINGS),
+            *generate_code(ASYNC_FUNCTION_TMPL, 2, docstring=REAL_DOCSTRINGS),
+            *generate_code(FUNCTION_TMPL, 2, docstring=REAL_DOCSTRINGS),
+            *generate_code(CLASS_TMPL, 2, docstring=REAL_DOCSTRINGS),
+            *generate_code(ASYNC_METHOD_TMPL, 3, docstring=REAL_DOCSTRINGS),
+            *generate_code(METHOD_TMPL, 3, docstring=REAL_DOCSTRINGS),
+            *generate_code(
+                COMMAND_ASYNC_FUNCTION_TMPL,
+                3,
+                docstring=REAL_DOCSTRINGS,
+                deco_name=FUNCTION_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_FUNCTION_TMPL, 4, docstring=REAL_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_CLASS_TMPL, 3, docstring=REAL_DOCSTRINGS, deco_name=CLASS_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_METHOD_TMPL,
+                4,
+                docstring=REAL_DOCSTRINGS,
+                deco_name=FUNCTION_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_METHOD_TMPL, 5, docstring=REAL_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+        ),
+    )
+    def test_real_docstrings(self, source: str, lineno: int) -> None:
+        extractor = get_extractor(source, self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile(
+            polib.POEntry(msgid="doc", occurrences=[(FILENAME, lineno)], flags=["docstring"])
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        (
+            *generate_code(MODULE_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(ASYNC_FUNCTION_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(FUNCTION_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(CLASS_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(ASYNC_METHOD_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(METHOD_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(
+                COMMAND_ASYNC_FUNCTION_TMPL,
+                docstring=FAKE_DOCSTRINGS,
+                deco_name=FUNCTION_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_FUNCTION_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_CLASS_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=CLASS_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_METHOD_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_METHOD_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+        ),
+    )
+    def test_fake_docstrings(self, source: str) -> None:
+        extractor = get_extractor(source, self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+
+class TestCommandDocstrings:
+    OPTIONS = Options(cmd_docstrings=True)
+
+    @pytest.mark.parametrize(
+        "source,lineno",
+        (
+            *generate_code(MODULE_TMPL, 1, docstring=REAL_DOCSTRINGS),
+            *generate_code(ASYNC_FUNCTION_TMPL, 2, docstring=REAL_DOCSTRINGS),
+            *generate_code(FUNCTION_TMPL, 2, docstring=REAL_DOCSTRINGS),
+            *generate_code(CLASS_TMPL, 2, docstring=REAL_DOCSTRINGS),
+            *generate_code(ASYNC_METHOD_TMPL, 3, docstring=REAL_DOCSTRINGS),
+            *generate_code(METHOD_TMPL, 3, docstring=REAL_DOCSTRINGS),
+        ),
+    )
+    def test_real_non_command_docstrings(self, source: str, lineno: int) -> None:
+        extractor = get_extractor(source, self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+    @pytest.mark.parametrize(
+        "source,lineno",
+        (
+            *generate_code(
+                COMMAND_ASYNC_FUNCTION_TMPL,
+                3,
+                docstring=REAL_DOCSTRINGS,
+                deco_name=FUNCTION_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_FUNCTION_TMPL, 4, docstring=REAL_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_CLASS_TMPL, 3, docstring=REAL_DOCSTRINGS, deco_name=CLASS_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_METHOD_TMPL,
+                4,
+                docstring=REAL_DOCSTRINGS,
+                deco_name=FUNCTION_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_METHOD_TMPL, 5, docstring=REAL_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+        ),
+    )
+    def test_real_command_docstrings(self, source: str, lineno: int) -> None:
+        extractor = get_extractor(source, self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile(
+            polib.POEntry(msgid="doc", occurrences=[(FILENAME, lineno)], flags=["docstring"])
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        (
+            *generate_code(MODULE_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(ASYNC_FUNCTION_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(FUNCTION_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(CLASS_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(ASYNC_METHOD_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(METHOD_TMPL, docstring=FAKE_DOCSTRINGS),
+            *generate_code(
+                COMMAND_ASYNC_FUNCTION_TMPL,
+                docstring=FAKE_DOCSTRINGS,
+                deco_name=FUNCTION_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_FUNCTION_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_CLASS_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=CLASS_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_METHOD_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_METHOD_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_FUNCTION_TMPL,
+                docstring=FAKE_DOCSTRINGS,
+                deco_name=INVALID_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_FUNCTION_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_CLASS_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_METHOD_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_METHOD_TMPL, docstring=FAKE_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+        ),
+    )
+    def test_fake_docstrings(self, source: str) -> None:
+        extractor = get_extractor(source, self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()
+
+
+class TestNoDocstrings:
+    OPTIONS = Options()
+
+    @pytest.mark.parametrize(
+        "source",
+        (
+            *generate_code(MODULE_TMPL, docstring=REAL_DOCSTRINGS),
+            *generate_code(ASYNC_FUNCTION_TMPL, docstring=REAL_DOCSTRINGS),
+            *generate_code(FUNCTION_TMPL, docstring=REAL_DOCSTRINGS),
+            *generate_code(CLASS_TMPL, docstring=REAL_DOCSTRINGS),
+            *generate_code(ASYNC_METHOD_TMPL, docstring=REAL_DOCSTRINGS),
+            *generate_code(METHOD_TMPL, docstring=REAL_DOCSTRINGS),
+            *generate_code(
+                COMMAND_ASYNC_FUNCTION_TMPL,
+                docstring=REAL_DOCSTRINGS,
+                deco_name=FUNCTION_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_FUNCTION_TMPL, docstring=REAL_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_CLASS_TMPL, docstring=REAL_DOCSTRINGS, deco_name=CLASS_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_METHOD_TMPL, docstring=REAL_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_METHOD_TMPL, docstring=REAL_DOCSTRINGS, deco_name=FUNCTION_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_FUNCTION_TMPL,
+                docstring=REAL_DOCSTRINGS,
+                deco_name=INVALID_DECORATORS,
+            ),
+            *generate_code(
+                COMMAND_FUNCTION_TMPL, docstring=REAL_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_CLASS_TMPL, docstring=REAL_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_ASYNC_METHOD_TMPL, docstring=REAL_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+            *generate_code(
+                COMMAND_METHOD_TMPL, docstring=REAL_DOCSTRINGS, deco_name=INVALID_DECORATORS
+            ),
+        ),
+    )
+    def test_docstrings(self, source: str) -> None:
+        extractor = get_extractor(source, self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile()

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -1,0 +1,19 @@
+from textwrap import dedent
+
+import polib
+
+from redgettext import Options
+from tests.utils import FILENAME, get_extractor, get_test_potfile
+
+
+def test_gettext_call_in_decorator_parameters_issue_6() -> None:
+    source = """\
+    class MyCog(commands.Cog):
+        @app_commands.command(name="command", description=_("English description"))
+        async def func(self):
+            ...
+    """
+    extractor = get_extractor(dedent(source), Options())
+    assert extractor.potfile_manager.current_potfile == get_test_potfile(
+        polib.POEntry(msgid="English description", occurrences=[(FILENAME, 2)])
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import polib
+
+from redgettext import MessageExtractor, Options, POTFileManager
+
+FILENAME = "file.py"
+
+
+def get_extractor(source: str, options: Options = Options()) -> MessageExtractor:
+    potfile_manager = POTFileManager(options)
+    potfile_manager.set_current_file(Path(FILENAME))
+    return MessageExtractor.extract_messages(source, potfile_manager)
+
+
+def get_test_potfile(*entries) -> polib.POFile:
+    potfile = polib.POFile()
+    potfile.metadata = POTFileManager.get_potfile_metadata()
+    potfile.extend(entries)
+    return potfile


### PR DESCRIPTION
While looking into #6, I've realised that using `tokenize` is a rather unnecessary hassle for us as detecting various syntactic constructs using bare tokens rather than a syntax tree is likely to cause problems as apparent by #7 and #8. Therefore I decided to rewrite redgettext to use a syntax tree.

As can be seen in commit history, I actually wanted to use LibCST initially but as described in [the commit refactoring LibCST implementation to ast module](https://github.com/Cog-Creators/redgettext/commit/3722a33a61941d04c743468218efc112df3d1330), the performance was subpar - generation took 18.2 seconds instead of the original implementation's 1.7 seconds. The new AST implementation actually beats both by taking around 0.8 seconds.

In the future, it's very possible we'll want to use LibCST (or something similar) to implement [Django-like Comments for translators functionality](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#comments-for-translators). It definitely doesn't seem worth it to pay the performance penalty until such a need arises though.

Fixes #6, fixes #7, fixes #8