### PR TITLE
Handle comments for translators

### DIFF
--- a/tests/comments_test.py
+++ b/tests/comments_test.py
@@ -1,0 +1,91 @@
+import polib
+
+from redgettext import Options
+from tests.utils import FILENAME, get_extractor, get_test_potfile
+
+OPTIONS = Options()
+SOURCE = """\
+# Translators: comment A1
+_('A') + _('B')
+
+# Translators: comment A2
+_('A'
+# Translators: comment B1
+) + _('B')
+
+# Translators: comment A3
+_('A') + _(
+    # Translators: comment B2
+    'B'
+)
+
+# Translators: comment A4
+_(
+# Translators: comment A5
+'A') + _('B')
+
+# Translators: comment AM1
+_('A'
+'multiline'
+# Translators: comment B3
+) + _('B')
+
+# Translators: comment C
+# multi-line
+_('C')
+
+# Translators: comment D
+
+# handles whitespace between
+
+# as long as there's no code between
+
+_('D')
+"""
+
+
+def test_comments() -> None:
+    extractor = get_extractor(SOURCE, OPTIONS)
+    expected = get_test_potfile(
+        polib.POEntry(
+            msgid="A",
+            occurrences=[(FILENAME, 2), (FILENAME, 5), (FILENAME, 10), (FILENAME, 16)],
+            comment=(
+                "Translators: comment A1\n"
+                "Translators: comment A2\n"
+                "Translators: comment A3\n"
+                "Translators: comment A4\n"
+                "Translators: comment A5"
+            ),
+        ),
+        polib.POEntry(
+            msgid="B",
+            occurrences=[
+                (FILENAME, 2),
+                (FILENAME, 7),
+                (FILENAME, 10),
+                (FILENAME, 18),
+                (FILENAME, 24),
+            ],
+            comment="Translators: comment B1\nTranslators: comment B2\nTranslators: comment B3",
+        ),
+        polib.POEntry(
+            msgid="Amultiline",
+            occurrences=[(FILENAME, 21)],
+            comment="Translators: comment AM1",
+        ),
+        polib.POEntry(
+            msgid="C", occurrences=[(FILENAME, 28)], comment="Translators: comment C\nmulti-line"
+        ),
+        polib.POEntry(
+            msgid="D",
+            occurrences=[(FILENAME, 36)],
+            comment=(
+                "Translators: comment D\n"
+                "handles whitespace between\n"
+                "as long as there's no code between"
+            ),
+        ),
+    )
+    assert str(extractor.potfile_manager.current_potfile) == str(expected)
+    assert extractor.potfile_manager.current_potfile == expected


### PR DESCRIPTION
Adds support for comments for translators - a way to give translators hints about a translatable string. To use this feature, a comment starting with "Translators: " prefix needs to be put on the line preceding the gettext (`_(...)`) call *or* on the line above the string literal *in* the gettext call.
Inline comments (i.e. comments put at the end of the line that contains code) are not supported.
The prefix is currently non-configurable. I could add an option and possibly choose a different default. I chose "Translators: " as that's what Django uses but it may be a little long.

This means that all of these work:
```py
# Translators: This is sent by the command changing bot's status, that is
# commands in the `[p]set status` command group. `{}` is replaced with
# Discord status name in English.
_("Status changed to {}.").format(status)

# Translators: This is sent by the command changing bot's status, that is
# commands in the `[p]set status` command group. `{}` is replaced with
# Discord status name in English.
very_long_variable = some_other_variable + _(
    "Status changed to {}."
).format(status)

very_long_variable = some_other_variable + _(
    # Translators: This is sent by the command changing bot's status, that is
    # commands in the `[p]set status` command group. `{}` is replaced with
    # Discord status name in English.
    "Status changed to {}."
).format(status)
```

While these don't:
```py
_("Status changed to {}.").format(status)  # Translators: inline comment

very_long_variable = some_other_variable + _(
    "Status changed to {}."  # Translators: inline comment
).format(status)

very_long_variable = some_other_variable + _(
    "Status changed to {}."
    # Translators: This is sent by the command changing bot's status, that is
    # commands in the `[p]set status` command group. `{}` is replaced with
    # Discord status name in English.
).format(status)
```

Additionally, when multiple gettext calls reside in the same line, the comment applies to the first call. This is not considered an issue as Python allows line breaks inside parentheses and as such the comment can simply be put before the string literal by using a multi-line call:
```py
# comment below is applied to "Status changed to " only

# Translators: This comment applies to "Status changed to " only
_("Status changed to ") + _("Do not disturb")

# Translators: This comment only applies to "Status changed to "
_("Status changed to ") + _(
    # Translators: This comment only applies to "Do not disturb"
    "Do not disturb"
)
```

---

Depends on the rewrite done in #9 
