### PR TITLE
Support more keywords (context-dependent translations and plural forms)

### DIFF
--- a/redgettext.py
+++ b/redgettext.py
@@ -591,6 +591,25 @@ def _parse_args(args: List[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--keyword",
+        "-k",
+        action="append",
+        default=[],
+        dest="keyword_specs",
+        help=(
+            "Specify keyword spec as an additional keyword to be looked for."
+            " This follows xgettext's keywordspec format with the exclusion of support for"
+            " GNOME glib syntax.\n"
+            "To disable default keywords, use `--no-default-keywords` flag."
+        ),
+    )
+    parser.add_argument(
+        "--no-default-keywords",
+        action="store_false",
+        dest="include_default_keywords",
+        help="Don't include default keywords.",
+    )
+    parser.add_argument(
         "--omit-empty",
         action="store_true",
         help="Empty .pot files will not be outputted.",
@@ -659,10 +678,6 @@ def main(args: Optional[List[str]] = None) -> int:
         args = sys.argv[1:]
 
     args = _parse_args(args)
-
-    # TODO: Make these an option
-    args.keyword_specs = []
-    args.include_default_keywords = True
 
     if args.version:
         print(f"redgettext {__version__}")

--- a/tests/call_test.py
+++ b/tests/call_test.py
@@ -1,4 +1,6 @@
+import ast
 from textwrap import dedent
+from typing import Tuple
 
 import polib
 import pytest
@@ -59,3 +61,53 @@ class TestGettextCalls:
         assert extractor.potfile_manager.current_potfile == get_test_potfile(
             polib.POEntry(msgid="bar", occurrences=[(FILENAME, 1)])
         )
+
+
+def parse_call(source: str, entry: polib.POEntry) -> Tuple[str, ast.Call, polib.POEntry]:
+    node = ast.parse(source).body[0].value
+    assert type(node) is ast.Call
+    return source, node, entry
+
+
+class TestKeywordSpecGettextCalls:
+    OPTIONS = Options(
+        keyword_specs=(
+            "_:2,2t",
+            "_:1,2,3t",
+            "_:1,2,3c,4t",
+            "_:1",
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "source,node,entry",
+        (
+            parse_call(
+                '_("singular")', polib.POEntry(msgid="singular", occurrences=[(FILENAME, 1)])
+            ),
+            parse_call(
+                '_("ignored", "singular")',
+                polib.POEntry(msgid="singular", occurrences=[(FILENAME, 1)]),
+            ),
+            parse_call(
+                '_("singular", "plural", "ignored")',
+                polib.POEntry(
+                    msgid="singular", msgid_plural="plural", occurrences=[(FILENAME, 1)]
+                ),
+            ),
+            parse_call(
+                '_("singular", "plural", "context", "ignored")',
+                polib.POEntry(
+                    msgid="singular",
+                    msgid_plural="plural",
+                    msgctxt="context",
+                    occurrences=[(FILENAME, 1)],
+                ),
+            ),
+        ),
+    )
+    def test_keyword_info_resolution(
+        self, source: str, node: ast.Call, entry: polib.POEntry
+    ) -> None:
+        extractor = get_extractor(source, self.OPTIONS)
+        assert extractor.potfile_manager.current_potfile == get_test_potfile(entry)

--- a/tests/comments_test.py
+++ b/tests/comments_test.py
@@ -3,7 +3,7 @@ import polib
 from redgettext import Options
 from tests.utils import FILENAME, get_extractor, get_test_potfile
 
-OPTIONS = Options()
+OPTIONS = Options(keyword_specs=("_:1", 'ngettext:1,2,"comment from keyword spec"'))
 SOURCE = """\
 # Translators: comment A1
 _('A') + _('B')
@@ -41,6 +41,12 @@ _('C')
 # as long as there's no code between
 
 _('D')
+
+# Translators: handles comments from keyspec too
+# no matter if there's a translator comment in code or not
+ngettext('E', 'F', 2)
+
+ngettext('G', 'H', 2)
 """
 
 
@@ -85,6 +91,22 @@ def test_comments() -> None:
                 "handles whitespace between\n"
                 "as long as there's no code between"
             ),
+        ),
+        polib.POEntry(
+            msgid="E",
+            msgid_plural="F",
+            occurrences=[(FILENAME, 40)],
+            comment=(
+                "Translators: handles comments from keyspec too\n"
+                "no matter if there's a translator comment in code or not\n"
+                "comment from keyword spec"
+            ),
+        ),
+        polib.POEntry(
+            msgid="G",
+            msgid_plural="H",
+            occurrences=[(FILENAME, 42)],
+            comment="comment from keyword spec",
         ),
     )
     assert str(extractor.potfile_manager.current_potfile) == str(expected)

--- a/tests/keyword_spec_parser_test.py
+++ b/tests/keyword_spec_parser_test.py
@@ -1,0 +1,161 @@
+import pytest
+
+from redgettext import DEFAULT_KEYWORD_SPECS, KeywordInfo, parse_keyword_specs
+
+
+@pytest.mark.parametrize(
+    "keyword_spec,expected",
+    (
+        # no/empty argument spec
+        ("gettext", KeywordInfo("gettext")),
+        ("gettext:", KeywordInfo("gettext")),
+        # default argument spec
+        ("gettext:1", KeywordInfo("gettext", arg_singular=0)),
+        # singular,plural
+        ("ngettext:1,2", KeywordInfo("ngettext", arg_singular=0, arg_plural=1)),
+        # singular,plural,context
+        ("custom:1,2,3c", KeywordInfo("custom", arg_singular=0, arg_plural=1, arg_context=2)),
+        # singular,plural,context,total
+        (
+            "custom:1,2,3c,3t",
+            KeywordInfo("custom", arg_singular=0, arg_plural=1, arg_context=2, total_arg_count=3),
+        ),
+        # singular,plural,total
+        (
+            "ngettext:1,2,2t",
+            KeywordInfo("ngettext", arg_singular=0, arg_plural=1, total_arg_count=2),
+        ),
+        # context,singular,plural,total
+        (
+            "npgettext:1c,2,3,3t",
+            KeywordInfo(
+                "npgettext", arg_singular=1, arg_plural=2, arg_context=0, total_arg_count=3
+            ),
+        ),
+        # context,singular,total
+        (
+            "npgettext:1c,2,3t",
+            KeywordInfo("npgettext", arg_singular=1, arg_context=0, total_arg_count=3),
+        ),
+        # comment,singular
+        ('custom:"com",2', KeywordInfo("custom", arg_singular=1, comment="com")),
+        # singular,comment,plural
+        ('custom:1,"com",2', KeywordInfo("custom", arg_singular=0, arg_plural=1, comment="com")),
+        # singular,plural,comment
+        ('custom:1,2,"com"', KeywordInfo("custom", arg_singular=0, arg_plural=1, comment="com")),
+        # singular,plural,comment,context,total,comment,comment
+        (
+            'custom:1,2,"com",3c,3t,"different com","com 3"',
+            KeywordInfo(
+                "custom",
+                arg_singular=0,
+                arg_plural=1,
+                arg_context=2,
+                total_arg_count=3,
+                comment="com\ndifferent com\ncom 3",
+            ),
+        ),
+        # singular,plural,context,total,comment
+        (
+            'custom:1,2,3c,3t,"com"',
+            KeywordInfo(
+                "custom",
+                arg_singular=0,
+                arg_plural=1,
+                arg_context=2,
+                total_arg_count=3,
+                comment="com",
+            ),
+        ),
+        # singular,context,comment,plural
+        (
+            'custom:1,3c,"com",2',
+            KeywordInfo("custom", arg_singular=0, arg_plural=1, arg_context=2, comment="com"),
+        ),
+        # singular,context,plural
+        ("custom:1,3c,2", KeywordInfo("custom", arg_singular=0, arg_plural=1, arg_context=2)),
+        # singular,context,plural,comment
+        (
+            'custom:1,3c,2,"com"',
+            KeywordInfo("custom", arg_singular=0, arg_plural=1, arg_context=2, comment="com"),
+        ),
+        # context,singular
+        ("custom:3c,2", KeywordInfo("custom", arg_singular=1, arg_context=2)),
+    ),
+)
+def test_passing(keyword_spec: str, expected: KeywordInfo) -> None:
+    output = KeywordInfo.from_spec(keyword_spec)
+    assert tuple(expected) == tuple(output)
+
+
+@pytest.mark.parametrize(
+    "keyword_spec",
+    (
+        "custom:1,2,1t",
+        "custom:2,1,1t",
+        "custom:1,2,3c,2t",
+        "custom:1,3,2c,2t",
+        "custom:2,1,3c,2t",
+        "custom:2,3,1c,2t",
+        "custom:3,1,2c,2t",
+        "custom:3,2,1c,2t",
+    ),
+)
+def test_failing_too_low_total_arg_count(keyword_spec: str) -> None:
+    pattern = r".* argument count cannot be lower than any .*"
+    with pytest.raises(ValueError, match=pattern):
+        KeywordInfo.from_spec(keyword_spec)
+
+
+@pytest.mark.parametrize("keyword_spec", ("_:2c", "_:2c,2t", "_:2t,2c", '_:"comment"'))
+def test_failing_singular_form_not_specified(keyword_spec: str) -> None:
+    with pytest.raises(ValueError, match=r".* singular form argument needs to be specified .*"):
+        KeywordInfo.from_spec(keyword_spec)
+
+
+@pytest.mark.parametrize("keyword_spec", ("_:c", "_:text", "_:3c2", '_:"text', '_:"blah'))
+def test_failing_bad_integer(keyword_spec: str) -> None:
+    with pytest.raises(ValueError, match=r"^'.*' is not a valid integer\.$"):
+        KeywordInfo.from_spec(keyword_spec)
+
+
+@pytest.mark.parametrize("keyword_spec", ('_:"', '_:text"', '_:text",1', '_:2,"', '_:1,",2'))
+def test_failing_missing_starting_quote(keyword_spec: str) -> None:
+    with pytest.raises(ValueError, match=r".* starting quote .*"):
+        KeywordInfo.from_spec(keyword_spec)
+
+
+@pytest.mark.parametrize("keyword_spec", ("_:0", "_:1,-1", "_:1,2,-5c"))
+def test_failing_numbers_below_1(keyword_spec: str) -> None:
+    with pytest.raises(ValueError, match=r".* Argument numbers start from 1\.$"):
+        KeywordInfo.from_spec(keyword_spec)
+
+
+@pytest.mark.parametrize("keyword_spec", ("_:1,1", "_:1,1,1c", "_:1,1,2c", "_:1,2,1c", "_:2,1,1c"))
+def test_duplicate_numbers(keyword_spec: str) -> None:
+    with pytest.raises(ValueError, match=r".* same argument number cannot be used .*"):
+        KeywordInfo.from_spec(keyword_spec)
+
+
+def test_parse_keyword_specs_order() -> None:
+    keywords = parse_keyword_specs(("_:1,2,3c,4t", "_:1", "_:1,2,3t", "_:2,2t"))
+    assert [2, 3, 4, None] == [ki.total_arg_count for ki in keywords["_"]]
+
+
+def test_parse_keyword_specs_failing_same_total_count_twice() -> None:
+    with pytest.raises(
+        ValueError, match=r".* total argument count 3 has been specified more than once\.$"
+    ):
+        parse_keyword_specs(("_:2,1,3t", "_:1,2,3t"))
+
+
+def test_parse_keyword_specs_failing_no_total_count_twice() -> None:
+    with pytest.raises(
+        ValueError, match=r".* no total argument count has been specified more than once\.$"
+    ):
+        parse_keyword_specs(("_:2,1", "_:1,2"))
+
+
+@pytest.mark.parametrize("keyword_spec", DEFAULT_KEYWORD_SPECS)
+def test_default_keyword_specs(keyword_spec: str) -> None:
+    KeywordInfo.from_spec(keyword_spec)


### PR DESCRIPTION
Adds support for xgettext's keyword specification (and allows using keyword specified in this format) bringing support for more arbitrary keyword names and argument counts. This brings support for context-dependent translations and plural forms on redgettext's side. Most of the work here was really the keyword specification parser.

---

Depends on rewrite in #9 and depends on #10 (though that can be avoided if there were a reason to first use this PR but I think #10 is more trivial)
Additionally, it would be good to have a working implementation of ngettext (plural support) in Red before proceeding with this.

Fixes #12 